### PR TITLE
Fix EXIF preservation when removal disabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -237,7 +237,12 @@ def fetch_and_process_image(
                 log_memory_usage(f"after EXIF removal for {filename}")
 
             # Save full-size image
-            processed_img.save(filepath, "JPEG", quality=APP_CONFIG["jpeg_quality"])
+            save_kwargs = {"format": "JPEG", "quality": APP_CONFIG["jpeg_quality"]}
+            if not remove_exif:
+                exif_bytes = img.info.get("exif")
+                if exif_bytes:
+                    save_kwargs["exif"] = exif_bytes
+            processed_img.save(filepath, **save_kwargs)
 
             # Create and save thumbnail
             thumbnail = processed_img.copy()


### PR DESCRIPTION
## Summary
- ensure EXIF metadata is saved when `remove_exif` is false

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb17c974c832488008adb85404186